### PR TITLE
Use dict literal

### DIFF
--- a/x.py
+++ b/x.py
@@ -116,7 +116,7 @@ def cmake(
     if generator is None and ninja_path is not None:
         generator = CMakeGenerator.ninja
     if defines is None:
-        defines = dict()
+        defines = {}
     argv = [
         'cmake',
         '-S',


### PR DESCRIPTION
This PR resolved the warning [`use-dict-literal / R1735`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-dict-literal.html).

I realize that this file is not in the main focus of this project, but one has to start somewhere.