### PR TITLE
No not initialize `_is_left` by itself

### DIFF
--- a/include/bolt/Either.hpp
+++ b/include/bolt/Either.hpp
@@ -54,7 +54,7 @@ public:
     _is_left(false), _right(std::move(right.value)) {}
 
   Either(const Either& other):
-    _is_left(_is_left) {
+    _is_left(other._is_left) {
       if (other._is_left) {
         new (&_left)L(other._left);
       } else {


### PR DESCRIPTION
This PR adds the missing `other` to avoid self initialization of `_is_left`.